### PR TITLE
refactor: Rename project from Varaoke Studio to StageSplit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Varaoke Studio
+# StageSplit
 
-Varaoke Studio is a Python-first karaoke workstation that combines a FastAPI backend with an Electron front-end. It downloads music videos from YouTube, separates them into stems with Demucs, and lets you remix, export, and project a karaoke-ready performance from within a dual-display operator console.
+StageSplit is a Python-first karaoke workstation that combines a FastAPI backend with an Electron front-end. It downloads music videos from YouTube, separates them into stems with Demucs, and lets you remix, export, and project a karaoke-ready performance from within a dual-display operator console.
 
 ## ✨ Features
 
@@ -34,8 +34,8 @@ Varaoke Studio is a Python-first karaoke workstation that combines a FastAPI bac
 ### 1. Clone & enter the repo
 
 ```bash
-git clone https://github.com/mdc159/Varaoke-Manus.git
-cd Varaoke-Manus
+git clone https://github.com/mdc159/StageSplit.git
+cd StageSplit
 ```
 
 ### 2. Bootstrap the backend environment

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "karaoke-studio-electron",
+  "name": "stagesplit",
   "version": "1.0.0",
   "main": "main.js",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "build": {
     "appId": "com.yourcompany.karaokestudio",
-    "productName": "KaraokeStudio",
+  "productName": "StageSplit",
     "files": [
       "main.js",
       "index.html",


### PR DESCRIPTION
This pull request updates the project's branding and naming to "StageSplit" across documentation and configuration files, replacing the previous "Varaoke Studio" and "KaraokeStudio" names. These changes ensure consistency and clarity for users and developers.

Branding and naming updates:

* Renamed all references to "Varaoke Studio" to "StageSplit" in the `README.md` project description.
* Updated repository clone instructions in `README.md` to use the new `StageSplit` repository name.
* Changed the project name from "karaoke-studio-electron" to "stagesplit" in `package.json`.
* Updated the product name from "KaraokeStudio" to "StageSplit" in the Electron build configuration in `package.json`.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Renamed the app from Varaoke Studio/KaraokeStudio to StageSplit for consistent branding and clearer naming.

Updated README title and clone instructions, and changed package.json "name" and Electron "productName" to StageSplit.

<!-- End of auto-generated description by cubic. -->

